### PR TITLE
修复pprof端点暴露/硬编码凭证/CORS配置等多处安全问题

### DIFF
--- a/conf/config.prd.yml
+++ b/conf/config.prd.yml
@@ -12,8 +12,8 @@ system:
   base-api: http://127.0.0.1:8080
   # 开启全局事务管理器
   transaction: true
-  # 是否初始化数据(没有初始数据时使用, 已发布正式版谨慎使用)
-  init-data: true
+  # 是否初始化数据(没有初始数据时使用, 生产环境应为false)
+  init-data: false
   # RSA私钥路径
   rsa-private-key-path: "./conf/rsa/rsa-private.pem"
   # RSA公钥路径

--- a/initialize/casbin.go
+++ b/initialize/casbin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go-gin-rest-api/pkg/global"
 	"go-gin-rest-api/pkg/utils"
+	"os"
 	"time"
 
 	"github.com/casbin/casbin/v2"
@@ -32,9 +33,13 @@ func InitCasbin() {
 	// 加载策略
 	global.CasbinACLEnforcer.StartAutoLoadPolicy(time.Minute * time.Duration(1))
 	//global.CasbinACLEnforcer.EnableEnforce(false)
-	// 添加API系统权限
-	global.CasbinACLEnforcer.AddPolicy("api-00000001", "/*", "*", "*", "(GET)|(POST)|(PUT)|(DELETE)|(OPTIONS)|(PATCH)", "allow")
-	global.CasbinACLEnforcer.AddPolicy("api-00000002", "/*", "*", "*", "(GET)|(POST)|(PUT)|(DELETE)|(OPTIONS)|(PATCH)", "allow")
+	// 添加API系统权限（仅当对应环境变量设置时才授权）
+	if os.Getenv("SYSTEM_API_SECRET_1") != "" {
+		global.CasbinACLEnforcer.AddPolicy("api-00000001", "/*", "*", "*", "(GET)|(POST)|(PUT)|(DELETE)|(OPTIONS)|(PATCH)", "allow")
+	}
+	if os.Getenv("SYSTEM_API_SECRET_2") != "" {
+		global.CasbinACLEnforcer.AddPolicy("api-00000002", "/*", "*", "*", "(GET)|(POST)|(PUT)|(DELETE)|(OPTIONS)|(PATCH)", "allow")
+	}
 	// 添加前台普通用户组权限
 	global.CasbinACLEnforcer.AddPolicy("group_user", "/*", "*", "*", "GET", "allow")
 	// 添加前台操作用户组权限

--- a/initialize/router.go
+++ b/initialize/router.go
@@ -62,7 +62,7 @@ func Routers() *gin.Engine {
 	// 添加跨域中间件, 让请求支持跨域
 	// 定义跨域配置
 	crosConfig := cors.Config{
-		AllowOrigins:     []string{"*", "http://localhost:3000", "http://127.0.0.1:3000"},
+		AllowOrigins:     []string{"http://localhost:3000", "http://127.0.0.1:3000"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Access-Control-Allow-Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization", "X-Auth-Token", "X-Real-IP"},
 		ExposeHeaders:    []string{"Content-Length"},
@@ -90,8 +90,10 @@ func Routers() *gin.Engine {
 			}),
 		),
 	)
-	// 初始化pprof
-	pprof.Register(r)
+	// 初始化pprof，仅非生产环境开启
+	if global.Conf.System.RunMode != "prd" {
+		pprof.Register(r)
+	}
 	// 初始化jwt auth中间件
 	authMiddleware, err := middleware.InitAuth()
 	if err != nil {

--- a/models/sys/sys_system.go
+++ b/models/sys/sys_system.go
@@ -3,6 +3,7 @@ package sys
 import (
 	"fmt"
 	"go-gin-rest-api/pkg/global"
+	"os"
 
 	loggable "github.com/linclin/gorm2-loggable"
 	"gorm.io/gorm"
@@ -45,7 +46,7 @@ func InitSysSystem() {
 				ID: 1,
 			},
 			AppId:      "api-00000001",
-			AppSecret:  "fa2e25cb060c8d748fd16ac5210581f41",
+			AppSecret:  os.Getenv("SYSTEM_API_SECRET_1"),
 			SystemName: "api",
 			IP:         "",
 			Operator:   "lc",
@@ -55,13 +56,17 @@ func InitSysSystem() {
 				ID: 2,
 			},
 			AppId:      "api-00000002",
-			AppSecret:  "61c94399f47c485334b48f8f340bc07b2",
+			AppSecret:  os.Getenv("SYSTEM_API_SECRET_2"),
 			SystemName: "UI",
 			IP:         "",
 			Operator:   "lc",
 		},
 	}
 	for _, system := range systems {
+		if system.AppSecret == "" {
+			global.Log.Info("跳过系统账号 " + system.AppId + "：未设置环境变量")
+			continue
+		}
 		err := global.DB.Where(&system).FirstOrCreate(&system).Error
 		if err != nil {
 			global.Log.Error(fmt.Sprint("InitSysSystem 数据初始化失败", err.Error()))


### PR DESCRIPTION
## 问题

在代码审计过程中发现了三处安全问题：

### 1. pprof调试端点未鉴权 (CWE-489)

`initialize/router.go` 中 `pprof.Register(r)` 直接注册在主路由上，没有任何鉴权中间件。任何人都可以访问 `/debug/pprof/heap`、`/debug/pprof/goroutine` 等端点获取堆内存快照和goroutine堆栈信息。

```go
// 修复前
pprof.Register(r)
```

这些信息可能泄露数据库连接串、内部API路径、函数调用栈等。

### 2. 硬编码系统API凭证 (CWE-798)

`models/sys/sys_system.go` 的 `InitSysSystem()` 中包含两套固定凭证：
- `api-00000001` / `fa2e25cb060c8d748fd16ac5210581f41`
- `api-00000002` / `61c94399f47c485334b48f8f340bc07b2`

同时 `initialize/casbin.go` 为这些AppId授予了 `/*` 通配符策略，意味着拿到凭证就能访问所有接口。

生产环境配置中 `init-data: true`，初次部署时会自动写入这些已知凭证。

### 3. CORS通配符与AllowCredentials冲突 (CWE-942)

`initialize/router.go` 的CORS配置同时设置了 `AllowOrigins: ["*"]` 和 `AllowCredentials: true`，这是无效组合，不符合CORS规范。

## 修复

1. pprof仅在非生产环境开启 (`RunMode != "prd"`)
2. 系统API凭证的AppSecret改为从环境变量 `SYSTEM_API_SECRET_1`/`SYSTEM_API_SECRET_2` 读取
3. casbin通配符策略仅在环境变量设置后才添加
4. 生产配置 `init-data` 默认改为 `false`
5. CORS AllowOrigins 移除通配符 `*`